### PR TITLE
Add smoke tests and workflow to run on Vercel Production deployments

### DIFF
--- a/.github/workflows/smoke-on-vercel-production.yml
+++ b/.github/workflows/smoke-on-vercel-production.yml
@@ -1,0 +1,61 @@
+name: Smoke on Vercel Production
+
+on:
+  deployment_status:
+    types: [success]
+
+permissions:
+  contents: read
+  deployments: read
+  statuses: write
+
+jobs:
+  smoke:
+    name: smoke
+    if: >-
+      ${{ github.event.deployment.environment && contains(github.event.deployment.environment, 'Production') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Extract Production URL
+        id: url
+        run: |
+          env_url="${{ github.event.deployment_status.environment_url }}"
+          target_url="${{ github.event.deployment_status.target_url }}"
+          final_url="$env_url"
+          if [ -z "$final_url" ]; then
+            final_url="$target_url"
+          fi
+          if [ -z "$final_url" ]; then
+            echo "No environment URL found on deployment_status event" >&2
+            exit 1
+          fi
+          echo "production_url=$final_url" >> "$GITHUB_OUTPUT"
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright smoke tests against Vercel Production
+        env:
+          BASE_URL: ${{ steps.url.outputs.production_url }}
+        run: npx playwright test tests/smoke.spec.ts --reporter=github,html
+
+      - name: Upload Playwright artifacts (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts-production
+          path: |
+            playwright-report
+            test-results
+          retention-days: 7

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+// Smoke tests are intentionally minimal and robust.
+
+// 1) Homepage loads and shows the main heading
+(test as any)('homepage loads and shows main heading', async ({ page }) => {
+  await page.goto('/');
+  const h1 = page.getByRole('heading', { level: 1 });
+  await expect(h1).toBeVisible();
+  await expect(h1).toHaveText(/\S/); // non-empty
+});
+
+// 2) Language switch (i18n) to DE shows translated string and sets html lang
+(test as any)('language switch to DE updates title and lang', async ({ page }) => {
+  await page.addInitScript(() => {
+    try { localStorage.setItem('lang', 'en'); } catch {}
+  });
+  await page.goto('/');
+
+  const flagDe = page.getByTestId('flag-de');
+  await flagDe.click();
+
+  // Wait for translated title
+  const deTitle = 'Italienische Karten — 300 Wörter';
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText(deTitle);
+
+  // html lang should be set to de
+  const htmlLang = await page.evaluate(() => document.documentElement.lang);
+  expect(htmlLang).toBe('de');
+});
+
+// 3) Critical route loads (Impressum page) and shows a key element/text
+(test as any)('impressum page loads and contains expected text', async ({ page }) => {
+  const resp = await page.goto('/impressum.html');
+  expect(resp && resp.ok()).toBeTruthy();
+  await expect(page.locator('body')).toContainText(/Impressum/i);
+});


### PR DESCRIPTION
- Add minimal Playwright smoke tests for homepage, language switch, and critical routes.
- Create GitHub Actions workflow to automatically run smoke tests on successful Production deployments.