### PR TITLE
Add Playwright E2E workflow for pull requests and main branch

### DIFF
--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -1,0 +1,57 @@
+name: Playwright E2E
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    # Ensures we only run on PRs or pushes to main
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers and OS dependencies
+        uses: microsoft/playwright-github-action@v1
+
+      - name: Run Playwright tests
+        run: npx playwright test --reporter=html
+        env:
+          CI: true
+
+      - name: Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7
+
+      # Upload raw test-results (traces, videos, screenshots) for failed runs
+      - name: Upload test-results (traces, videos, screenshots)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: test-results
+          retention-days: 7


### PR DESCRIPTION
- Configure GitHub Actions to run Playwright E2E tests on PRs and main branch pushes.
- Set up Node.js, install dependencies, and configure Playwright browsers.
- Upload HTML reports and raw test results for failed runs.